### PR TITLE
feat(cli): 为 run/worker 命令增加 --stdout 输出控制

### DIFF
--- a/src-new/astrbot_sdk/cli.py
+++ b/src-new/astrbot_sdk/cli.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import json
+import os
 import re
 import sys
 import typing
@@ -95,7 +95,7 @@ def _resolve_cli_stdout_target(target: str | None) -> str:
 
     Values:
       - None: default to "silent" on TTY, otherwise "console"
-      - "silent": write to an in-memory buffer (StringIO/BytesIO)
+      - "silent": discard protocol stdout
       - "console": write to process stdout (pass stdout=None)
       - other: treated as a filesystem path
     """
@@ -120,7 +120,9 @@ def _open_cli_protocol_stdout(
     if target == "console":
         return None
     if target == "silent":
-        return io.BytesIO() if wire_codec == "msgpack" else io.StringIO()
+        # Never buffer protocol stdout in memory: long-running sessions can OOM.
+        # Use a discard sink instead.
+        return stack.enter_context(open(os.devnull, "wb"))
 
     path = Path(target)
     if wire_codec == "msgpack":
@@ -921,7 +923,7 @@ def cli(ctx, verbose: bool) -> None:
     show_default="silent",
     metavar="silent|console|PATH",
     help=(
-        "Where to write protocol stdout: silent, console, or a file path. "
+        "Where to write protocol stdout: silent (discard), console, or a file path. "
         "Defaults to silent on TTY; console when stdout is piped."
     ),
 )
@@ -1097,7 +1099,7 @@ def dev(
     show_default="silent",
     metavar="silent|console|PATH",
     help=(
-        "Where to write protocol stdout: silent, console, or a file path. "
+        "Where to write protocol stdout: silent (discard), console, or a file path. "
         "Defaults to silent on TTY; console when stdout is piped."
     ),
 )

--- a/tests_v4/test_cli_stdout.py
+++ b/tests_v4/test_cli_stdout.py
@@ -41,24 +41,28 @@ def test_resolve_stdout_default_is_console_when_piped(monkeypatch) -> None:
     assert _resolve_cli_stdout_target(None) == "console"
 
 
-def test_open_stdout_silent_json_returns_stringio() -> None:
+def test_open_stdout_silent_json_returns_discard_sink() -> None:
     with ExitStack() as stack:
         stdout = _open_cli_protocol_stdout(
             target="silent",
             wire_codec="json",
             stack=stack,
         )
-        assert isinstance(stdout, io.StringIO)
+        assert isinstance(stdout, io.BufferedIOBase)
+        assert stdout.write(b"hello\n") == len(b"hello\n")
+        stdout.flush()
 
 
-def test_open_stdout_silent_msgpack_returns_bytesio() -> None:
+def test_open_stdout_silent_msgpack_returns_discard_sink() -> None:
     with ExitStack() as stack:
         stdout = _open_cli_protocol_stdout(
             target="silent",
             wire_codec="msgpack",
             stack=stack,
         )
-        assert isinstance(stdout, io.BytesIO)
+        assert isinstance(stdout, io.BufferedIOBase)
+        assert stdout.write(b"\x01\x02") == 2
+        stdout.flush()
 
 
 def test_open_stdout_file_json(tmp_path) -> None:
@@ -85,4 +89,3 @@ def test_open_stdout_file_msgpack(tmp_path) -> None:
         assert isinstance(stdout, io.BufferedIOBase)
         stdout.write(b"\x01\x02")
     assert out_path.read_bytes() == b"\x01\x02"
-


### PR DESCRIPTION
## 一、PR 概述
为 `astrbot_sdk` 的 `run`/`worker` 命令新增 `--stdout` 输出口参数，可选择将运行时协议输出写入内存（静默）、控制台或文件；
Fixed #8 

---

## 二、背景 / 动机
- 调试/集成场景需要可控的“协议 stdout”去向：有时需要输出到控制台（便于观察），有时需要写文件（便于抓包/回放），交互式场景则需要默认静默以避免污染终端。

---

## 三、改动内容
- CLI：
  - 为 `python -m astrbot_sdk run` 与 `python -m astrbot_sdk worker` 新增 `--stdout silent|console|PATH` 选项。
  - `silent` 时按 codec 创建内存 stdout：`msgpack -> io.BytesIO()`，`json -> io.StringIO()`。
  - `console` 时不创建 stdout（向运行时传 `stdout=None`），由运行时使用进程 `sys.stdout`。
  - `PATH` 时将协议输出写入文件：`json` 以 UTF-8 文本写入；`msgpack` 以二进制写入。
  - 默认行为：TTY 下默认 `silent`；stdout 被 pipe/重定向时默认 `console`（避免 supervisor/worker stdio 通信被静默吞掉）。
- 测试：
  - 新增 `tests_v4/test_cli_stdout.py` 覆盖 `--help` 展示、默认策略与 stdout stream 创建行为。

---

## 四、实现说明
- `src-new/astrbot_sdk/cli.py` 增加内部工具函数：
  - `_resolve_cli_stdout_target(target)`：将 `--stdout` 参数归一化，并在未显式传参时根据 `sys.stdout.isatty()` 选择 `silent/console`。
  - `_open_cli_protocol_stdout(target, wire_codec, stack)`：按目标创建 `IO[str] | IO[bytes] | None`，并用 `ExitStack` 管理文件句柄生命周期。
- `run`/`worker` 入口统一将 `stdout` 传入 `run_supervisor` / `run_plugin_worker`（不再依赖未定义的外部变量）。

---

## 五、行为变化（对外影响）
- 之前：
  - 无法通过 CLI 选择协议输出目的地。
- 现在：
  - 新增 `--stdout`，支持 `silent/console/文件` 三种输出路径。
  - 默认在交互式终端静默；在被 pipe/重定向时默认输出到 stdout，保证 stdio transport 正常工作。

示例：
```bash
# 输出到控制台 stdout（协议输出走 stdout，日志仍走 stderr）
python -m astrbot_sdk run --stdout console

# 输出到文件
python -m astrbot_sdk run --stdout out.json
python -m astrbot_sdk worker --wire-codec msgpack --stdout out.bin
```

---

## 六、文件变更统计
- 新增文件：1
- 修改文件：7

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `.gitignore` | 修改 | 忽略部分本地/示例目录 |
| `pyproject.toml` | 修改 | pytest 收集/缓存目录配置（避免权限导致的收集失败） |
| `src-new/astrbot_sdk/cli.py` | 修改 | 为 `run`/`worker` 增加 `--stdout` 与 stdout 创建逻辑 |
| `src-new/astrbot_sdk/runtime/bootstrap.py` | 修改 | 补充注释/文档 |
| `src-new/astrbot_sdk/runtime/supervisor.py` | 修改 | 补充注释/文档 |
| `src-new/astrbot_sdk/runtime/transport.py` | 修改 | 补充注释/文档 |
| `tests_v4/conftest.py` | 修改 | Windows 下 tmp 目录/权限兼容处理 |
| `tests_v4/test_cli_stdout.py` | 新增 | 覆盖 `--stdout` 行为的单测 |

---

## 七、测试与验证
已验证：
```bash
python run_tests.py -k "test_cli_stdout"
```

备注：
- 在当前环境中，完整测试集里 `tests_v4/test_transport.py` 的 “process mode” 子进程相关用例可能因系统权限/沙箱限制出现 `WinError 5`（与本 PR 变更无直接耦合）。

---

## 八、Checklist
- [x] 功能变更已补充测试
- [x] CLI 帮助信息可见且参数行为明确
- [ ] ruff format / ruff check（如本地环境可用，建议提交前执行）

## 运行截图
<img width="1897" height="1809" alt="d68a7f825c72b9eee1b7b786b3a228a8" src="https://github.com/user-attachments/assets/83c54b9f-4240-4f36-b18e-add54a8fc348" />
