### PR TITLE
fix(cli): route protocol stdout at command entry

### DIFF
--- a/src/astrbot_sdk/cli.py
+++ b/src/astrbot_sdk/cli.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
 import typing
@@ -24,7 +25,7 @@ from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import IO, Any
 
 import click
 from loguru import logger
@@ -151,6 +152,52 @@ def _run_sync_entrypoint(
         if exit_code == EXIT_UNEXPECTED:
             logger.exception("CLI 异常退出")
         raise SystemExit(exit_code) from exc
+
+
+def _resolve_protocol_stdout(
+    protocol_stdout: str | None,
+) -> tuple[IO[str] | None, IO[str] | None]:
+    target = protocol_stdout
+    if target is None:
+        target = "silent" if sys.stdout.isatty() else "console"
+    if target == "console":
+        return sys.stdout, None
+    if target == "silent":
+        opened_stdout = open(os.devnull, "w", encoding="utf-8")
+        return opened_stdout, opened_stdout
+    opened_stdout = open(target, "w", encoding="utf-8")
+    return opened_stdout, opened_stdout
+
+
+async def _run_supervisor_with_protocol_stdout(
+    *,
+    plugins_dir: Path,
+    protocol_stdout: str | None,
+) -> None:
+    transport_stdout, opened_stdout = _resolve_protocol_stdout(protocol_stdout)
+    try:
+        await run_supervisor(plugins_dir=plugins_dir, stdout=transport_stdout)
+    finally:
+        if opened_stdout is not None:
+            opened_stdout.close()
+
+
+async def _run_worker_with_protocol_stdout(
+    *,
+    plugin_dir: Path | None,
+    group_metadata: Path | None,
+    protocol_stdout: str | None,
+) -> None:
+    transport_stdout, opened_stdout = _resolve_protocol_stdout(protocol_stdout)
+    try:
+        await run_plugin_worker(
+            plugin_dir=plugin_dir,
+            group_metadata=group_metadata,
+            stdout=transport_stdout,
+        )
+    finally:
+        if opened_stdout is not None:
+            opened_stdout.close()
 
 
 def _classify_cli_exception(exc: Exception) -> tuple[int, str, str]:
@@ -846,12 +893,24 @@ def cli(ctx, verbose: bool) -> None:
     type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
     help="Directory containing plugin folders",
 )
-def run(plugins_dir: Path) -> None:
+@click.option(
+    "--protocol-stdout",
+    default=None,
+    type=str,
+    help=(
+        "Where to write protocol stdout: silent (discard), console, or a file "
+        "path. Defaults to silent on TTY; console when stdout is piped."
+    ),
+)
+def run(plugins_dir: Path, protocol_stdout: str | None) -> None:
     """Start the plugin supervisor over stdio."""
     _run_async_entrypoint(
-        run_supervisor(plugins_dir=plugins_dir),
+        _run_supervisor_with_protocol_stdout(
+            plugins_dir=plugins_dir,
+            protocol_stdout=protocol_stdout,
+        ),
         log_message=f"启动插件主管进程，插件目录：{plugins_dir}",
-        context={"plugins_dir": plugins_dir},
+        context={"plugins_dir": plugins_dir, "protocol_stdout": protocol_stdout},
     )
 
 
@@ -987,7 +1046,20 @@ def dev(
     required=False,
     type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
 )
-def worker(plugin_dir: Path | None, group_metadata: Path | None) -> None:
+@click.option(
+    "--protocol-stdout",
+    default=None,
+    type=str,
+    help=(
+        "Where to write protocol stdout: silent (discard), console, or a file "
+        "path. Defaults to silent on TTY; console when stdout is piped."
+    ),
+)
+def worker(
+    plugin_dir: Path | None,
+    group_metadata: Path | None,
+    protocol_stdout: str | None,
+) -> None:
     """Internal command used by the supervisor to start a worker."""
     if plugin_dir is None and group_metadata is None:
         raise click.UsageError("Either --plugin-dir or --group-metadata is required")
@@ -997,15 +1069,16 @@ def worker(plugin_dir: Path | None, group_metadata: Path | None) -> None:
         )
 
     target = str(group_metadata or plugin_dir)
-    if group_metadata is not None:
-        entrypoint = run_plugin_worker(group_metadata=group_metadata)
-    else:
-        entrypoint = run_plugin_worker(plugin_dir=plugin_dir)
+    entrypoint = _run_worker_with_protocol_stdout(
+        plugin_dir=plugin_dir,
+        group_metadata=group_metadata,
+        protocol_stdout=protocol_stdout,
+    )
     _run_async_entrypoint(
         entrypoint,
         log_message=f"启动插件工作进程：{target}",
         log_level="debug",
-        context={"plugin_dir": plugin_dir},
+        context={"plugin_dir": plugin_dir, "protocol_stdout": protocol_stdout},
     )
 
 

--- a/tests/test_protocol_stdout.py
+++ b/tests/test_protocol_stdout.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from astrbot_sdk import cli
+
+
+class _FakeStream(io.StringIO):
+    def __init__(self, *, is_tty: bool) -> None:
+        super().__init__()
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+def test_resolve_protocol_stdout_defaults_to_silent_on_tty(monkeypatch) -> None:
+    fake_stdout = _FakeStream(is_tty=True)
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+
+    transport_stdout, opened_stdout = cli._resolve_protocol_stdout(None)
+
+    assert opened_stdout is not None
+    assert transport_stdout is opened_stdout
+    assert getattr(transport_stdout, "name", None) == os.devnull
+    opened_stdout.close()
+
+
+def test_resolve_protocol_stdout_defaults_to_console_when_stdout_is_piped(
+    monkeypatch,
+) -> None:
+    fake_stdout = _FakeStream(is_tty=False)
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+
+    transport_stdout, opened_stdout = cli._resolve_protocol_stdout(None)
+
+    assert transport_stdout is fake_stdout
+    assert opened_stdout is None
+
+
+def test_resolve_protocol_stdout_supports_file_path(
+    monkeypatch, tmp_path: Path
+) -> None:
+    fake_stdout = _FakeStream(is_tty=True)
+    output_path = tmp_path / "protocol.log"
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+
+    transport_stdout, opened_stdout = cli._resolve_protocol_stdout(str(output_path))
+
+    assert opened_stdout is not None
+    assert transport_stdout is opened_stdout
+    assert getattr(transport_stdout, "name", None) == str(output_path)
+    opened_stdout.close()
+
+
+def test_run_command_resolves_protocol_stdout_to_stream(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run_supervisor(*, plugins_dir: Path, stdout=None, **_) -> None:
+        captured["plugins_dir"] = plugins_dir
+        captured["stdout_name"] = getattr(stdout, "name", None)
+
+    def fake_run_async_entrypoint(entrypoint, **_) -> None:
+        asyncio.run(entrypoint)
+
+    monkeypatch.setattr(cli, "run_supervisor", fake_run_supervisor)
+    monkeypatch.setattr(cli, "_run_async_entrypoint", fake_run_async_entrypoint)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["run", "--plugins-dir", str(tmp_path), "--protocol-stdout", "silent"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "plugins_dir": tmp_path,
+        "stdout_name": os.devnull,
+    }
+
+
+def test_worker_command_resolves_protocol_stdout_to_stream(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    output_path = tmp_path / "worker-protocol.log"
+
+    async def fake_run_plugin_worker(
+        *,
+        plugin_dir: Path | None = None,
+        group_metadata: Path | None = None,
+        stdout=None,
+        **_,
+    ) -> None:
+        captured["plugin_dir"] = plugin_dir
+        captured["group_metadata"] = group_metadata
+        captured["stdout_name"] = getattr(stdout, "name", None)
+
+    def fake_run_async_entrypoint(entrypoint, **_) -> None:
+        asyncio.run(entrypoint)
+
+    monkeypatch.setattr(cli, "run_plugin_worker", fake_run_plugin_worker)
+    monkeypatch.setattr(cli, "_run_async_entrypoint", fake_run_async_entrypoint)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "worker",
+            "--plugin-dir",
+            str(plugin_dir),
+            "--protocol-stdout",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "plugin_dir": plugin_dir,
+        "group_metadata": None,
+        "stdout_name": str(output_path),
+    }


### PR DESCRIPTION
## 一、PR 概述

为 `astr run` 和内部 `worker` 命令新增 `--protocol-stdout` 参数，并在 CLI 入口阶段将其解析为具体的输出流，避免 stdio 协议被普通 stdout 输出污染。

---

## 二、背景 / 动机

- `astr run` 使用 stdio 作为协议通道时，普通 `stdout` 输出可能混入协议流，导致脏日志或协议污染。
- 这次修复按最小改动原则处理，不修改 `_prepare_stdio_transport()` 和 `run_supervisor()` 的协议路由逻辑。
- 输出目标在 CLI 命令入口直接收敛为实际 `stdout` 句柄后再传入 runtime。

---

## 三、改动内容

- 为 `run` 命令新增 `--protocol-stdout`
- 为内部 `worker` 命令新增 `--protocol-stdout`
- 在 CLI 中新增协议 stdout 解析逻辑，支持：
  - `silent`
  - `console`
  - 文件路径
- 默认行为：
  - TTY 下默认 `silent`
  - stdout 被 pipe 时默认 `console`
- 在 CLI 包装层负责打开和关闭协议输出文件句柄
- 新增定向测试覆盖默认值、文件路径和 CLI 入口解析行为
- 新增修复计划文档

**改动类型**
- [ ] 新功能
- [x] 缺陷修复
- [x] 重构/整理
- [ ] 性能优化
- [x] 文档更新
- [x] 测试补充
- [ ] 依赖/配置变更

---

## 四、实现说明

- **核心思路**：在 CLI 入口将 `--protocol-stdout` 解析成真实 `stdout` 流对象，再调用现有 `run_supervisor(..., stdout=...)` / `run_plugin_worker(..., stdout=...)`
- **设计取舍**：
  - 不修改 `_prepare_stdio_transport()`
  - 不修改 `run_supervisor()` 的协议行为
  - 不把参数透传到 runtime 结构内部
  - 保持修复点尽量靠近用户输入层
- **主要涉及文件**：
  - `src/astrbot_sdk/cli.py`
  - `tests/test_protocol_stdout.py`

---

## 五、行为变化

- **之前**：
  - CLI 没有显式控制协议 stdout 去向
  - 普通 stdout 输出可能污染 stdio 协议
- **现在**：
  - 可以通过 `--protocol-stdout silent|console|PATH` 控制协议 stdout
  - 未指定时，TTY 默认静默，pipe 默认继续输出到控制台
- **兼容性影响**：
  - 默认行为更安全
  - 不影响已有 runtime 内部接口签名

---

## 六、测试与验证

**已验证**
- [x] 本地定向测试通过
- [x] ruff check 通过

**测试命令**
```bash
.\.venv\Scripts\ruff.exe check src/astrbot_sdk/cli.py src/astrbot_sdk/runtime/supervisor.py tests/test_protocol_stdout.py --fix
.\.venv\Scripts\python.exe -m pytest tests/test_protocol_stdout.py -q
```
<img width="1476" height="345" alt="09b9cf5ffb71d9a4e8b50dad7cc0fcee" src="https://github.com/user-attachments/assets/cfbf6125-365c-439b-9120-7715c53c84dd" />
<img width="933" height="125" alt="e864abbecd3fc98504c8b4053a0764c3" src="https://github.com/user-attachments/assets/a21f2fc5-24a7-4925-9948-593fbc8575ed" />
<img width="1895" height="391" alt="image" src="https://github.com/user-attachments/assets/6b4ec295-b02c-4ed6-82ab-13ee5effeec2" />
