### PR TITLE
 fix(runtime): 修复 message_history 与 HTTP 路由校验问题

### DIFF
--- a/src/astrbot_sdk/clients/managers.py
+++ b/src/astrbot_sdk/clients/managers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -58,6 +58,17 @@ def _normalize_message_history_parts(
             )
         normalized.append(component_to_payload_sync(part))
     return normalized
+
+
+def _normalize_message_history_boundary(value: datetime) -> str:
+    if not isinstance(value, datetime):
+        raise TypeError("message_history boundary requires datetime")
+    normalized = value
+    if normalized.tzinfo is None:
+        normalized = normalized.replace(tzinfo=timezone.utc)
+    else:
+        normalized = normalized.astimezone(timezone.utc)
+    return normalized.isoformat()
 
 
 class PersonaRecord(_ManagerModel):
@@ -677,7 +688,7 @@ class MessageHistoryManagerClient:
             "message_history.delete_before",
             {
                 "session": _require_message_history_session(session),
-                "before": before.isoformat(),
+                "before": _normalize_message_history_boundary(before),
             },
         )
         return int(output.get("deleted_count", 0) or 0)
@@ -692,7 +703,7 @@ class MessageHistoryManagerClient:
             "message_history.delete_after",
             {
                 "session": _require_message_history_session(session),
-                "after": after.isoformat(),
+                "after": _normalize_message_history_boundary(after),
             },
         )
         return int(output.get("deleted_count", 0) or 0)

--- a/src/astrbot_sdk/protocol/_builtin_schemas.py
+++ b/src/astrbot_sdk/protocol/_builtin_schemas.py
@@ -722,7 +722,7 @@ MESSAGE_HISTORY_PAGE_SCHEMA = _object_schema(
 MESSAGE_HISTORY_LIST_INPUT_SCHEMA = _object_schema(
     required=("session",),
     session=MESSAGE_HISTORY_SESSION_SCHEMA,
-    cursor=_nullable({"type": "string"}),
+    cursor=_nullable({"type": "string", "pattern": "^(|[1-9][0-9]*)$"}),
     limit={"type": "integer", "minimum": 1},
 )
 MESSAGE_HISTORY_LIST_OUTPUT_SCHEMA = _object_schema(

--- a/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/http.py
+++ b/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/http.py
@@ -6,19 +6,29 @@ from typing import Any
 from ....errors import AstrBotError
 from ..bridge_base import CapabilityRouterBridgeBase
 
-# 路由只允许字母、数字、/, -, _, . 以及路径参数 {param}，且必须以 / 开头
-# 禁止 .. 防止路径遍历，禁止连续斜杠
-_ROUTE_SAFE_RE = re.compile(r"^(/[\w\-._{}]*)+$")
+# 路由只允许字母、数字、/, -, _, . 以及路径参数 {param}，且必须以 / 开头。
+# 参数段必须完整地形如 {param}，同时禁止空段（例如连续斜杠）。
+_ROUTE_SEGMENT_RE = re.compile(r"^(?:[\w\-._]+|\{[\w\-._]+\})$")
 
 
 def _validate_route(route: str, capability_name: str) -> None:
     """校验 HTTP 路由路径格式，阻止路径遍历和非法字符。"""
     if ".." in route:
         raise AstrBotError.invalid_input(f"{capability_name}: 路由路径不允许包含 '..'")
-    if not _ROUTE_SAFE_RE.match(route):
+    if not route.startswith("/"):
         raise AstrBotError.invalid_input(
             f"{capability_name}: 路由路径格式非法，只允许字母/数字/-/_/./{{param}} 段，"
             "且必须以 / 开头，如 /foo/bar"
+        )
+    if route == "/":
+        return
+    segments = route.split("/")[1:]
+    if any(
+        not segment or not _ROUTE_SEGMENT_RE.fullmatch(segment) for segment in segments
+    ):
+        raise AstrBotError.invalid_input(
+            f"{capability_name}: 路由路径格式非法，只允许字母/数字/-/_/./{{param}} 段，"
+            "禁止连续斜杠，且必须以 / 开头，如 /foo/bar"
         )
 
 

--- a/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/message_history.py
+++ b/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/message_history.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ....errors import AstrBotError
@@ -17,6 +17,16 @@ def _session_payload(session: MessageSession) -> dict[str, str]:
 
 
 class MessageHistoryCapabilityMixin(CapabilityRouterBridgeBase):
+    @staticmethod
+    def _normalize_timestamp(raw_value: Any) -> datetime:
+        normalized = str(raw_value or "").strip()
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
     @staticmethod
     def _typed_session_from_payload(payload: Any) -> MessageSession:
         if not isinstance(payload, dict):
@@ -133,7 +143,7 @@ class MessageHistoryCapabilityMixin(CapabilityRouterBridgeBase):
                 f"message_history.{field_name} requires {field_name}"
             )
         try:
-            return datetime.fromisoformat(text)
+            return MessageHistoryCapabilityMixin._normalize_timestamp(text)
         except ValueError as exc:
             raise AstrBotError.invalid_input(
                 f"message_history.{field_name} requires an ISO datetime string"
@@ -147,8 +157,14 @@ class MessageHistoryCapabilityMixin(CapabilityRouterBridgeBase):
         limit = 50 if raw_limit is None else raw_limit
         if limit < 1:
             raise AstrBotError.invalid_input("message_history.list requires limit >= 1")
-        cursor = payload.get("cursor")
-        cursor_id = int(str(cursor)) if cursor not in (None, "") else None
+        raw_cursor = payload.get("cursor")
+        cursor_id = (
+            self._optional_int(raw_cursor) if raw_cursor not in (None, "") else None
+        )
+        if raw_cursor not in (None, "") and (cursor_id is None or cursor_id < 1):
+            raise AstrBotError.invalid_input(
+                "message_history.list requires cursor to be a positive integer string"
+            )
         records = list(reversed(self._message_history_records(session)))
         total = len(records)
         if cursor_id is not None:
@@ -247,7 +263,7 @@ class MessageHistoryCapabilityMixin(CapabilityRouterBridgeBase):
         retained: list[dict[str, Any]] = []
         deleted_count = 0
         for record in records:
-            created_at = datetime.fromisoformat(str(record.get("created_at")))
+            created_at = self._normalize_timestamp(record.get("created_at"))
             if created_at < before:
                 deleted_count += 1
                 continue
@@ -264,7 +280,7 @@ class MessageHistoryCapabilityMixin(CapabilityRouterBridgeBase):
         retained: list[dict[str, Any]] = []
         deleted_count = 0
         for record in records:
-            created_at = datetime.fromisoformat(str(record.get("created_at")))
+            created_at = self._normalize_timestamp(record.get("created_at"))
             if created_at > after:
                 deleted_count += 1
                 continue

--- a/tests/test_http_runtime.py
+++ b/tests/test_http_runtime.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from astrbot_sdk._internal.invocation_context import caller_plugin_scope
+from astrbot_sdk.errors import AstrBotError
 from astrbot_sdk.runtime.capability_router import CapabilityRouter
 
 
@@ -93,3 +94,26 @@ async def test_http_unregister_subset_preserves_other_methods(
             }
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_http_register_rejects_routes_with_empty_segments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    router = CapabilityRouter()
+
+    with pytest.raises(AstrBotError) as exc_info:
+        await _call(
+            router,
+            "http.register_api",
+            {
+                "route": "/foo//bar",
+                "methods": ["GET"],
+                "handler_capability": "demo.handler",
+                "description": "demo",
+            },
+        )
+
+    assert exc_info.value.code == "invalid_input"

--- a/tests/test_message_history_runtime.py
+++ b/tests/test_message_history_runtime.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from astrbot_sdk._internal.testing_support import MockContext
+from astrbot_sdk.errors import AstrBotError
 from astrbot_sdk.message.components import Plain
 from astrbot_sdk.message.session import MessageSession
 
@@ -124,3 +125,79 @@ async def test_mock_context_message_history_round_trip_and_aliases() -> None:
         record.id
         for record in (await ctx.message_history.list(group_session, limit=10)).records
     ] == [group_record.id]
+
+
+@pytest.mark.asyncio
+async def test_message_history_delete_boundaries_normalize_naive_datetime_to_utc() -> (
+    None
+):
+    ctx = MockContext(plugin_id="sdk-demo")
+    session = MessageSession(
+        platform_id="demo-platform",
+        message_type="private",
+        session_id="user-1",
+    )
+
+    first = await ctx.message_history.append(
+        session,
+        parts=[Plain("first", convert=False)],
+        sender={"sender_id": "sender-1", "sender_name": "Tester"},
+    )
+    second = await ctx.message_history.append(
+        session,
+        parts=[Plain("second", convert=False)],
+        sender={"sender_id": "sender-2", "sender_name": "Tester 2"},
+    )
+    third = await ctx.message_history.append(
+        session,
+        parts=[Plain("third", convert=False)],
+        sender={"sender_id": "sender-3", "sender_name": "Tester 3"},
+    )
+
+    store = ctx.router._message_history_store[_session_store_key(session)]
+    timestamps = {
+        first.id: "2026-03-20T00:00:00+00:00",
+        second.id: "2026-03-21T00:00:00+00:00",
+        third.id: "2026-03-22T00:00:00+00:00",
+    }
+    for record in store:
+        stamped = timestamps.get(int(record["id"]))
+        if stamped is None:
+            continue
+        record["created_at"] = stamped
+        record["updated_at"] = stamped
+
+    deleted_before = await ctx.message_history.delete_before(
+        session,
+        before=datetime(2026, 3, 21, 0, 0),
+    )
+    assert deleted_before == 1
+
+    deleted_after = await ctx.message_history.delete_after(
+        session,
+        after=datetime(2026, 3, 21, 12, 0),
+    )
+    assert deleted_after == 1
+
+    remaining = await ctx.message_history.list(session, limit=10)
+    assert [record.id for record in remaining.records] == [second.id]
+
+
+@pytest.mark.asyncio
+async def test_message_history_list_invalid_cursor_returns_invalid_input() -> None:
+    ctx = MockContext(plugin_id="sdk-demo")
+    session = MessageSession(
+        platform_id="demo-platform",
+        message_type="private",
+        session_id="user-1",
+    )
+    await ctx.message_history.append(
+        session,
+        parts=[Plain("first", convert=False)],
+        sender={"sender_id": "sender-1", "sender_name": "Tester"},
+    )
+
+    with pytest.raises(AstrBotError) as exc_info:
+        await ctx.message_history.list(session, cursor="abc")
+
+    assert exc_info.value.code == "invalid_input"


### PR DESCRIPTION
  ## 变更说明

  本 PR 修复了最近引入的 3 个运行时校验问题：

  1. 修复 `message_history.delete_before()` / `delete_after()` 对 naive `datetime` 处理不一致的问题
     - 运行时存储的 `created_at` 为带时区的 UTC 时间
     - 调用方传入 naive `datetime` 时，原实现会在比较时触发 `TypeError`
     - 现在会在 client / runtime 两侧统一将边界时间归一化为 UTC 后再比较
     - 这一行为与项目内其他时间处理逻辑保持一致，避免同类接口出现不一致的时区语义

  2. 修复 `message_history.list` 对非法 `cursor` 抛裸 `ValueError` 的问题
     - 之前 schema 允许任意字符串，但 handler 内部直接执行 `int(str(cursor))`
     - 现在 schema 仅接受空字符串或正整数字符串
     - handler 也会对非法输入稳定返回 `invalid_input`，不再泄漏内部异常

  3. 修复 `http.register_api` 路由校验未拦截连续斜杠的问题
     - 之前的正则会错误接受 `/foo//bar`
     - 现在改为按 path segment 校验
     - 明确拒绝空路径段，同时保留 `/` 根路径和合法 `{param}` 段的支持

  ## 影响范围

  - `message_history` 时间边界删除
  - `message_history.list` 分页游标校验
  - `http.register_api` 路由合法性校验

  ## 测试

  新增 / 更新了以下测试：

  - `tests/test_message_history_runtime.py`
    - 覆盖 naive `datetime` 会被归一化为 UTC 的删除场景
    - 覆盖非法 `cursor` 返回 `invalid_input`
  - `tests/test_http_runtime.py`
    - 覆盖带空路径段的非法路由（如 `/foo//bar`）会被拒绝

  本地验证通过：

  ```bash
  python -m pytest tests/test_message_history_runtime.py tests/test_http_runtime.py -q
  ```

  ## 兼容性说明

  - 这次对 message_history 的时间处理属于“放宽输入并规范化语义”，不会破坏原有传入 aware datetime 的调用方
  - cursor="" 仍保持原有“等价于不传游标”的行为
  - HTTP 路由校验变严格后，原先错误接受的连续斜杠路径将被拒绝，这属于预期修复