### PR TITLE
feat: 为 astr init 补充默认 agent 指引并统一错误模型说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ astr init my-plugin
 astr init my-plugin --agents claude,codex
 ```
 
+`astr init <name>` 会生成插件骨架，并默认附带根级 `AGENTS.md` / `CLAUDE.md` 开发说明。传入 `--agents` 时，会在新插件目录下额外生成对应的项目级 agent 目录：
+
+- Claude Code: `.claude/skills/astrbot-plugin-dev/`
+- Codex: `.agents/skills/astrbot-plugin-dev/`
+- OpenCode: `.opencode/skills/astrbot-plugin-dev/`
+
+`--agents` 仅支持 `claude`、`codex`、`opencode`，使用逗号分隔；重复值会去重，非法值会直接报错。
+
 ### 第一个插件
 
 ```python
@@ -190,7 +198,6 @@ ruff check . --fix
 ---
 
 ## 相关资源
-
 - **AstrBot 主项目**: https://github.com/AstrBotDevs/AstrBot
 - **Python 版本**: >= 3.12
 - **SDK 版本**: v4.0

--- a/src/astrbot_sdk/cli.py
+++ b/src/astrbot_sdk/cli.py
@@ -56,6 +56,8 @@ BUILD_EXCLUDED_DIRS = {
     "dist",
 }
 BUILD_EXCLUDED_FILES = {
+    "AGENTS.md",
+    "CLAUDE.md",
     ".astrbot-worker-state.json",
 }
 WATCH_POLL_INTERVAL_SECONDS = 0.5
@@ -719,6 +721,8 @@ def _render_init_readme(*, plugin_name: str) -> str:
 
         ```
         .
+        ├── AGENTS.md
+        ├── CLAUDE.md
         ├── plugin.yaml
         ├── requirements.txt
         ├── main.py
@@ -741,6 +745,41 @@ def _render_init_readme(*, plugin_name: str) -> str:
         ```
         """
     )
+
+
+def _render_init_agent_notes(*, title: str, plugin_name: str) -> str:
+    return dedent(
+        f"""\
+        # {title}
+
+        ## Plugin Context
+
+        - Plugin name: `{plugin_name}`
+        - Plugin type: AstrBot SDK v4 plugin
+
+        ## Error Handling Rules
+
+        - For expected plugin errors, use `AstrBotError` from `astrbot_sdk.errors`.
+        - Select stable error codes from `ErrorCodes`; prefer existing factory helpers such as `AstrBotError.invalid_input(...)`, `AstrBotError.internal_error(...)`, `AstrBotError.network_error(...)`, and `AstrBotError.capability_not_found(...)`.
+        - Keep the SDK error payload shape consistent: `code`, `message`, `hint`, `details`, `docs_url`, `retryable`.
+        - Do not invent ad-hoc primary error contracts like `{{"error": "..."}}` when the operation should fail; raise `AstrBotError` so SDK CLI, local harness, and AstrBot bridge layers can render errors consistently.
+
+        ## Development Rules
+
+        - Prefer the stable public SDK surface: `astrbot_sdk`, `astrbot_sdk.decorators`, `astrbot_sdk.clients`, `astrbot_sdk.testing`.
+        - Avoid runtime internals such as `astrbot_sdk.runtime.*` in plugin code unless you are explicitly changing the SDK itself.
+        - Use `ctx.logger.debug(...)` for local debug output in `astrbot-sdk dev --local`.
+        - In tests, prefer `PluginHarness.from_plugin_dir(...)`; avoid `from main import ...`, which can pollute `sys.modules`.
+        """
+    )
+
+
+def _render_init_agents_md(*, plugin_name: str) -> str:
+    return _render_init_agent_notes(title="AGENTS Notes", plugin_name=plugin_name)
+
+
+def _render_init_claude_md(*, plugin_name: str) -> str:
+    return _render_init_agent_notes(title="CLAUDE Notes", plugin_name=plugin_name)
 
 
 def _render_init_test_py(*, plugin_name: str) -> str:
@@ -981,6 +1020,14 @@ def _init_plugin(name: str | None, agents: tuple[str, ...] = ()) -> None:
     )
     (target_dir / "README.md").write_text(
         _render_init_readme(plugin_name=plugin_name),
+        encoding="utf-8",
+    )
+    (target_dir / "AGENTS.md").write_text(
+        _render_init_agents_md(plugin_name=plugin_name),
+        encoding="utf-8",
+    )
+    (target_dir / "CLAUDE.md").write_text(
+        _render_init_claude_md(plugin_name=plugin_name),
         encoding="utf-8",
     )
     (target_dir / "tests" / "test_plugin.py").write_text(

--- a/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/SKILL.md
+++ b/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/SKILL.md
@@ -117,6 +117,12 @@ If `astrbot-sdk` is not on PATH, use `python -m astrbot_sdk <subcommand>` instea
 - **NEVER** store `ctx` on `self` outside the active handler or lifecycle call.
 - In `on_start` / `on_stop`, always call `await super().on_start(ctx)` / `await super().on_stop(ctx)`.
 
+### Error handling
+- For expected failures, raise `AstrBotError` from `astrbot_sdk.errors` instead of inventing ad-hoc exception or payload formats.
+- Reuse stable `ErrorCodes` and factory helpers such as `AstrBotError.invalid_input(...)`, `AstrBotError.internal_error(...)`, `AstrBotError.network_error(...)`, and `AstrBotError.capability_not_found(...)`.
+- Keep error output consistent with the SDK contract: `code`, `message`, `hint`, `details`, `docs_url`, `retryable`.
+- Do not use `{"error": "..."}` as the primary failure contract for HTTP/capability handlers when the operation should fail; raise `AstrBotError` so CLI, local harness, and AstrBot bridge surfaces stay aligned.
+
 ### Client API semantics (prevents common bugs)
 - `ctx.db.delete(key)` returns **None**, not bool. Check existence with `ctx.db.get()` first if you need to know.
 - `ctx.db.get(key)` returns **None** for missing keys, does not raise.

--- a/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/api-quick-ref.md
+++ b/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/api-quick-ref.md
@@ -1,5 +1,22 @@
 # API Quick Reference
 
+## Errors
+
+Use the SDK's unified error model for expected failures:
+
+```python
+from astrbot_sdk.errors import AstrBotError, ErrorCodes
+
+raise AstrBotError.invalid_input(
+    "session_id and message are required",
+    hint="Provide both session_id and message",
+)
+```
+
+- Prefer `AstrBotError` over ad-hoc `{"error": ...}` payloads when the operation should fail.
+- Reuse stable `ErrorCodes` and existing factory helpers where possible.
+- The SDK error contract is `code`, `message`, `hint`, `details`, `docs_url`, `retryable`.
+
 ## Trigger Decorators
 
 ### @on_command

--- a/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/plugin-patterns.md
+++ b/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/plugin-patterns.md
@@ -293,6 +293,7 @@ Expose REST endpoints.
 
 **main.py:**
 ```python
+from astrbot_sdk.errors import AstrBotError
 from astrbot_sdk import Context, Star
 from astrbot_sdk.decorators import http_api
 
@@ -307,7 +308,10 @@ class WebhookPlugin(Star):
         target = payload.get("session_id", "")
         message = payload.get("message", "")
         if not target or not message:
-            return {"error": "session_id and message required"}
+            raise AstrBotError.invalid_input(
+                "session_id and message are required",
+                hint="Provide both session_id and message",
+            )
         await ctx.platform.send(target, message)
         return {"sent": True}
 ```

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -21,6 +21,11 @@ def test_init_normalizes_plugin_name_and_adds_prefix() -> None:
         assert "name: astrbot_plugin_demo_plugin" in manifest
         assert "display_name: demo-plugin" in manifest
         assert "version: 1.0.0" in manifest
+        agents_notes = (plugin_dir / "AGENTS.md").read_text(encoding="utf-8")
+        claude_notes = (plugin_dir / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "AstrBotError" in agents_notes
+        assert "ErrorCodes" in agents_notes
+        assert "AstrBotError" in claude_notes
         assert not (plugin_dir / ".claude").exists()
         assert not (plugin_dir / ".agents").exists()
         assert not (plugin_dir / ".opencode").exists()
@@ -64,6 +69,8 @@ def test_init_generates_claude_agent_directory() -> None:
         assert "astrbot_plugin_demo_plugin" in content
         assert "name: astrbot-plugin-dev" in content
         assert "Plugin root: `../../..`" in content
+        assert "AstrBotError" in content
+        assert "ErrorCodes" in content
         assert (
             plugin_dir
             / ".claude"
@@ -182,6 +189,8 @@ def test_build_excludes_generated_agent_skill_directories() -> None:
 
         assert "plugin.yaml" in names
         assert "main.py" in names
+        assert "AGENTS.md" not in names
+        assert "CLAUDE.md" not in names
         assert all(not name.startswith(".claude/") for name in names)
         assert all(not name.startswith(".agents/") for name in names)
         assert all(not name.startswith(".opencode/") for name in names)


### PR DESCRIPTION
  ## 变更内容

  - `astr init` 默认生成根级 `AGENTS.md` 和 `CLAUDE.md`
  - 更新 `.claude/.agents/.opencode` 下的 skill 模板说明
  - 明确插件开发中的可预期错误统一使用 `AstrBotError / ErrorCodes`
  - 修正文档示例中不一致的错误写法
  - 补充对应的 init / build 测试