### PR TITLE
优化 astr init --agents 生成的插件开发 skill 依赖版本约束说明

### DIFF
--- a/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/SKILL.md
+++ b/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/SKILL.md
@@ -93,6 +93,12 @@ from astrbot_sdk.decorators import validate_config
 
 **Never use in plugin code:** `astrbot_sdk.runtime.*`, Worker/Supervisor, Loader, Peer/Transport internals.
 
+### Dependency version constraints
+
+- Unless there is a strong reason not to, declare direct plugin dependencies with the verified minimum compatible version, for example `package>=1.2.3`, instead of exact pins like `package==1.2.3`.
+- If a known incompatible major version or bad release exists, add an upper bound or exclusion too, for example `package>=1.2.3,<3.0.0` or `package>=1.2.3,!=2.4.1`.
+- Exact `==` pins are for the rare cases where the plugin truly requires one build and the reason is documented in code or release notes.
+
 ## Step 4 — Validate and test
 
 ```bash

--- a/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/project-structure.md
+++ b/src/astrbot_sdk/templates/skills/astrbot-plugin-dev/references/project-structure.md
@@ -38,6 +38,21 @@ astrbot_plugin_my_plugin/
     └── test_plugin.py       # Tests (recommended)
 ```
 
+## requirements.txt guidance
+
+Prefer direct dependencies with verified minimum compatible versions so environment grouping can reuse compatible plugin sets:
+
+```txt
+httpx>=0.27.0
+pydantic>=2.7.0,<3.0.0
+some-sdk>=1.4.2,!=1.6.0
+```
+
+Notes:
+- Unless there is a strong reason not to, use minimum-version constraints (`>=`) instead of exact `==` pins for direct dependencies.
+- If a known incompatible major version or problem release exists, add an upper bound (`<`) or exclusion (`!=`) at the same time.
+- Use exact `==` only when the plugin truly depends on one specific build and you can justify that choice.
+
 ## CLI Commands
 
 All commands support two entrypoints. If `astrbot-sdk` is not on PATH, use `python -m astrbot_sdk`:

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -71,6 +71,8 @@ def test_init_generates_claude_agent_directory() -> None:
         assert "Plugin root: `../../..`" in content
         assert "AstrBotError" in content
         assert "ErrorCodes" in content
+        assert "verified minimum compatible version" in content
+        assert "upper bound or exclusion" in content
         assert (
             plugin_dir
             / ".claude"


### PR DESCRIPTION
## 变更内容

调整 `astr init --agents` 生成的插件开发 skill 文案，明确插件依赖版本约束应优先使用“已验证的最低兼容版本”，而不是默认写成精确版本。

新增说明包括：

- 除非有充分理由，插件的直接依赖应使用 `>=` 声明最低兼容版本，而不是 `==`
- 如果已知存在不兼容的大版本或问题版本，应补充上界 `<` 或排除约束 `!=`
- 只有在确实必须锁定到单一版本时，才使用精确版本，并应能说明原因

同时补充了 `requirements.txt` 的示例说明，并更新了 CLI 初始化测试，确保生成出的 skill 包含这条新规则。

## 变更原因

当前 skill 对插件依赖版本约束的引导不够明确，容易让生成结果直接使用 `==` 锁版本，不利于后续环境分组和依赖复用。这次调整后，默认生成策略会更符合插件开发和环境管理的实际需求。