### PR TITLE
test: 修复 test_runtime_worker.py 中的硬编码 Unix 路径以提高跨平台兼容性

### DIFF
--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -27,8 +27,11 @@ from astrbot_sdk.runtime.worker import (
 )
 
 
-def _plugin_spec(name: str) -> PluginSpec:
-    plugin_dir = Path(f"/tmp/{name}")
+def _plugin_spec(name: str, tmp_path: Path | None = None) -> PluginSpec:
+    import tempfile
+
+    base_dir = tmp_path if tmp_path else Path(tempfile.gettempdir())
+    plugin_dir = base_dir / name
     return PluginSpec(
         name=name,
         plugin_dir=plugin_dir,
@@ -71,9 +74,11 @@ async def test_plugin_worker_handle_cancel_fans_out_to_both_dispatchers() -> Non
 
 
 @pytest.mark.asyncio
-async def test_plugin_worker_start_initializes_metadata_and_handlers() -> None:
+async def test_plugin_worker_start_initializes_metadata_and_handlers(
+    tmp_path: Path,
+) -> None:
     runtime = object.__new__(PluginWorkerRuntime)
-    runtime.plugin = _plugin_spec("alpha")
+    runtime.plugin = _plugin_spec("alpha", tmp_path)
     runtime.worker_id = "alpha-worker"
     runtime.loaded_plugin = LoadedPlugin(
         plugin=runtime.plugin,
@@ -137,9 +142,11 @@ async def test_plugin_worker_start_initializes_metadata_and_handlers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_plugin_worker_start_runs_on_stop_when_initialize_fails() -> None:
+async def test_plugin_worker_start_runs_on_stop_when_initialize_fails(
+    tmp_path: Path,
+) -> None:
     runtime = object.__new__(PluginWorkerRuntime)
-    runtime.plugin = _plugin_spec("alpha")
+    runtime.plugin = _plugin_spec("alpha", tmp_path)
     runtime.worker_id = "alpha-worker"
     runtime.loaded_plugin = LoadedPlugin(
         plugin=runtime.plugin,
@@ -183,9 +190,11 @@ async def test_plugin_worker_start_runs_on_stop_when_initialize_fails() -> None:
 
 
 @pytest.mark.asyncio
-async def test_group_worker_start_raises_when_all_plugins_become_inactive() -> None:
+async def test_group_worker_start_raises_when_all_plugins_become_inactive(
+    tmp_path: Path,
+) -> None:
     runtime = object.__new__(GroupWorkerRuntime)
-    alpha = _plugin_spec("alpha")
+    alpha = _plugin_spec("alpha", tmp_path)
     runtime.worker_id = "worker-group"
     runtime.plugins = [alpha]
     runtime._plugin_states = [
@@ -241,14 +250,16 @@ async def test_group_worker_start_raises_when_all_plugins_become_inactive() -> N
     assert refresh_snapshots[-1] == []
 
 
-def test_group_worker_initialize_metadata_aggregates_runtime_state() -> None:
+def test_group_worker_initialize_metadata_aggregates_runtime_state(
+    tmp_path: Path,
+) -> None:
     class _RiskyPlugin:
         pass
 
     setattr(_RiskyPlugin, GLOBAL_MCP_RISK_ATTR, True)
 
-    alpha = _plugin_spec("alpha")
-    beta = _plugin_spec("beta")
+    alpha = _plugin_spec("alpha", tmp_path)
+    beta = _plugin_spec("beta", tmp_path)
     alpha_capability = LoadedCapability(
         descriptor=CapabilityDescriptor(
             name="alpha.echo",


### PR DESCRIPTION
- 将 _plugin_spec() 函数中的硬编码 /tmp 路径替换为跨平台的临时目录
- 使用 pytest 的 tmp_path fixture 或 tempfile.gettempdir() 作为后备
- 更新所有使用 _plugin_spec() 的测试函数以接受 tmp_path 参数
- 修复了在 Windows 等 Unix 以外的平台上运行测试时的潜在路径问题

影响范围: tests/test_runtime_worker.py