### PR TITLE
fix :bug: : 修复插件依赖环境异常状态处理

### DIFF
--- a/src/astrbot_sdk/runtime/environment_groups.py
+++ b/src/astrbot_sdk/runtime/environment_groups.py
@@ -563,6 +563,7 @@ class GroupEnvironmentManager:
             not group.python_path.exists()
             or not self._matches_python_version(group.venv_path, group.python_version)
             or not group.lockfile_path.exists()
+            or state is None
         ):
             self._rebuild(group)
             self._write_state(state_path, group)
@@ -639,14 +640,14 @@ class GroupEnvironmentManager:
         return _read_pyvenv_major_minor(venv_path / "pyvenv.cfg") == version
 
     @staticmethod
-    def _load_state(state_path: Path) -> dict[str, object]:
+    def _load_state(state_path: Path) -> dict[str, object] | None:
         if not state_path.exists():
             return {}
         try:
             data = json.loads(state_path.read_text(encoding="utf-8"))
-        except Exception:
-            return {}
-        return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return None
+        return data if isinstance(data, dict) else None
 
     @staticmethod
     def _write_state(state_path: Path, group: EnvironmentGroup) -> None:

--- a/src/astrbot_sdk/runtime/loader.py
+++ b/src/astrbot_sdk/runtime/loader.py
@@ -977,6 +977,10 @@ class PluginEnvironmentManager:
             self._plan_result is None
             or plugin.name not in self._plan_result.plugin_to_group
         ):
+            if self._plan_result is not None:
+                reason = self._plan_result.skipped_plugins.get(plugin.name)
+                if reason is not None:
+                    raise RuntimeError(reason)
             planned_plugins = (
                 list(self._plan_result.plugins) if self._plan_result else []
             )

--- a/tests/test_runtime_environment_groups.py
+++ b/tests/test_runtime_environment_groups.py
@@ -7,11 +7,12 @@ import pytest
 
 from astrbot_sdk.runtime.environment_groups import (
     EnvironmentGroup,
+    EnvironmentPlanResult,
     EnvironmentPlanner,
     GROUP_STATE_FILE_NAME,
     GroupEnvironmentManager,
 )
-from astrbot_sdk.runtime.loader import PluginSpec
+from astrbot_sdk.runtime.loader import PluginEnvironmentManager, PluginSpec
 
 
 def _plugin_spec(
@@ -208,3 +209,61 @@ def test_group_environment_manager_prepare_syncs_existing_env_when_state_changed
     assert calls == ["sync:alpha"]
     updated_state = json.loads(state_path.read_text(encoding="utf-8"))
     assert updated_state["environment_fingerprint"] == "new-fingerprint"
+
+
+def test_group_environment_manager_prepare_rebuilds_when_state_is_corrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = _plugin_spec(tmp_path, "alpha")
+    group = _group(tmp_path, plugin)
+    group.venv_path.mkdir(parents=True, exist_ok=True)
+    group.lockfile_path.parent.mkdir(parents=True, exist_ok=True)
+    group.lockfile_path.write_text("# lock\n", encoding="utf-8")
+    group.python_path.parent.mkdir(parents=True, exist_ok=True)
+    group.python_path.write_text("", encoding="utf-8")
+    (group.venv_path / "pyvenv.cfg").write_text("version = 3.10.9\n", encoding="utf-8")
+    state_path = group.venv_path / GROUP_STATE_FILE_NAME
+    state_path.write_text("{not-json", encoding="utf-8")
+    manager = GroupEnvironmentManager(tmp_path, uv_binary="uv")
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        manager,
+        "_rebuild",
+        lambda current_group: calls.append(f"rebuild:{current_group.id}"),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_sync_existing",
+        lambda current_group: calls.append(f"sync:{current_group.id}"),
+    )
+
+    assert manager.prepare(group) == group.python_path
+
+    assert calls == ["rebuild:alpha"]
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated_state["environment_fingerprint"] == "fingerprint"
+
+
+def test_plugin_environment_manager_prepare_environment_raises_skipped_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = _plugin_spec(tmp_path, "alpha")
+    manager = PluginEnvironmentManager(tmp_path, uv_binary="uv")
+    manager._plan_result = EnvironmentPlanResult(
+        plugins=[],
+        plugin_to_group={},
+        skipped_plugins={"alpha": "dependency conflict"},
+    )
+    monkeypatch.setattr(
+        manager,
+        "plan",
+        lambda _plugins: pytest.fail(
+            "prepare_environment should not replan an already skipped plugin"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="dependency conflict"):
+        manager.prepare_environment(plugin)


### PR DESCRIPTION
## Summary

Fixes #118.

- Treat corrupt or non-object group environment state as untrusted and force a rebuild instead of syncing an existing venv.
- Preserve the original `skipped_plugins` reason when `PluginEnvironmentManager.prepare_environment()` is called for a plugin that planning already skipped.
- Add regression tests for both #118 contract paths.

## Verification

- `python -m pytest tests/test_runtime_environment_groups.py -q` -> `6 passed`
- `python -m pytest tests/test_runtime_supervisor_registry_sync.py tests/test_runtime_worker.py -q` -> `17 passed`
- `ruff check . --fix` -> `All checks passed!`
- `ruff format .` -> `154 files left unchanged`
- `python -m pytest tests -q` -> `320 passed, 3 warnings`
