### PR TITLE
fix :bug: : 校验 direct worker 插件清单

### DIFF
--- a/src/astrbot_sdk/runtime/worker.py
+++ b/src/astrbot_sdk/runtime/worker.py
@@ -16,11 +16,12 @@
 启动流程：
     Worker 启动:
         1. load_plugin_spec() 加载插件规范
-        2. load_plugin() 加载插件组件
-        3. 创建 Peer 并设置处理器
-        4. 向 Supervisor 发送 initialize
-        5. 等待 Supervisor 的 initialize_result
-        6. 执行 on_start 生命周期回调
+        2. validate_plugin_spec() 校验插件清单
+        3. load_plugin() 加载插件组件
+        4. 创建 Peer 并设置处理器
+        5. 向 Supervisor 发送 initialize
+        6. 等待 Supervisor 的 initialize_result
+        7. 执行 on_start 生命周期回调
 """
 
 from __future__ import annotations
@@ -45,6 +46,7 @@ from .loader import (
     load_plugin,
     load_plugin_config,
     load_plugin_spec,
+    validate_plugin_spec,
 )
 from .peer import Peer
 
@@ -62,6 +64,13 @@ class GroupPluginRuntimeState:
     plugin: PluginSpec
     loaded_plugin: LoadedPlugin
     lifecycle_context: RuntimeContext
+
+
+def _load_validated_plugin_spec(plugin_dir: Path) -> PluginSpec:
+    """加载并校验插件清单，避免 direct worker 路径绕过发现阶段约束。"""
+    plugin = load_plugin_spec(plugin_dir)
+    validate_plugin_spec(plugin)
+    return plugin
 
 
 def _load_group_plugin_specs(group_metadata_path: Path) -> tuple[str, list[PluginSpec]]:
@@ -92,7 +101,7 @@ def _load_group_plugin_specs(group_metadata_path: Path) -> tuple[str, list[Plugi
             raise RuntimeError(
                 f"worker group metadata contains invalid plugin_dir: {group_metadata_path}"
             )
-        plugins.append(load_plugin_spec(Path(plugin_dir)))
+        plugins.append(_load_validated_plugin_spec(Path(plugin_dir)))
 
     group_id = payload.get("group_id")
     if not isinstance(group_id, str) or not group_id:
@@ -103,7 +112,7 @@ def _load_group_plugin_specs(group_metadata_path: Path) -> tuple[str, list[Plugi
 def _load_plugin_specs(plugin_dirs: list[Path]) -> list[PluginSpec]:
     if not plugin_dirs:
         raise RuntimeError("worker requires at least one plugin directory")
-    return [load_plugin_spec(plugin_dir) for plugin_dir in plugin_dirs]
+    return [_load_validated_plugin_spec(plugin_dir) for plugin_dir in plugin_dirs]
 
 
 def _build_worker_registry_entry(
@@ -422,7 +431,7 @@ class PluginWorkerRuntime:
         worker_id: str | None = None,
         wire_codec: ProtocolCodec | None = None,
     ) -> None:
-        self.plugin = load_plugin_spec(plugin_dir)
+        self.plugin = _load_validated_plugin_spec(plugin_dir)
         self.worker_id = str(worker_id or self.plugin.name)
         self.transport = transport
         self.wire_codec = wire_codec or MsgpackProtocolCodec()

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -744,6 +744,7 @@ def test_plugin_and_group_worker_runtime_default_codec_use_msgpack_peer(
             plugin_dir=plugin_dir,
         ),
     )
+    monkeypatch.setattr(worker_module, "validate_plugin_spec", lambda plugin: None)
     monkeypatch.setattr(
         worker_module,
         "load_plugin",
@@ -807,6 +808,7 @@ def test_plugin_and_group_worker_runtime_explicit_json_codec_use_json_peer(
             plugin_dir=plugin_dir,
         ),
     )
+    monkeypatch.setattr(worker_module, "validate_plugin_spec", lambda plugin: None)
     monkeypatch.setattr(
         worker_module,
         "load_plugin",

--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -24,6 +25,7 @@ from astrbot_sdk.runtime.worker import (
     GroupWorkerRuntime,
     PluginWorkerRuntime,
 )
+import astrbot_sdk.runtime.worker as worker_module
 
 
 def _plugin_spec(name: str, tmp_path: Path | None = None) -> PluginSpec:
@@ -39,6 +41,92 @@ def _plugin_spec(name: str, tmp_path: Path | None = None) -> PluginSpec:
         python_version="3.10",
         manifest_data={"name": name},
     )
+
+
+def _write_worker_plugin_dir(
+    plugin_dir: Path,
+    *,
+    include_author: bool = True,
+    include_repo: bool = True,
+) -> None:
+    lines = [
+        "name: worker_manifest_plugin",
+        'runtime: {"python": "3.10"}',
+        "components:",
+        "  - class: main:WorkerTestPlugin",
+    ]
+    if include_author:
+        lines.append("author: tests")
+    if include_repo:
+        lines.append("repo: united-pooh/astrbot-sdk")
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (plugin_dir / "requirements.txt").write_text("", encoding="utf-8")
+    (plugin_dir / "main.py").write_text(
+        "from astrbot_sdk import Star\n\nclass WorkerTestPlugin(Star):\n    pass\n",
+        encoding="utf-8",
+    )
+
+
+def _fail_if_plugin_code_loads(_plugin: PluginSpec) -> LoadedPlugin:
+    pytest.fail("direct worker should validate plugin.yaml before loading plugin code")
+
+
+def test_plugin_worker_runtime_validates_manifest_before_loading_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = tmp_path / "missing_author"
+    _write_worker_plugin_dir(plugin_dir, include_author=False)
+    monkeypatch.setattr(worker_module, "load_plugin", _fail_if_plugin_code_loads)
+
+    with pytest.raises(ValueError, match="缺少 author"):
+        PluginWorkerRuntime(plugin_dir=plugin_dir, transport=SimpleNamespace())
+
+
+def test_group_worker_runtime_validates_plugin_dirs_before_loading_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = tmp_path / "missing_repo"
+    _write_worker_plugin_dir(plugin_dir, include_repo=False)
+    monkeypatch.setattr(worker_module, "load_plugin", _fail_if_plugin_code_loads)
+
+    with pytest.raises(ValueError, match="缺少 repo"):
+        GroupWorkerRuntime(
+            transport=SimpleNamespace(),
+            plugin_dirs=[plugin_dir],
+        )
+
+
+def test_group_worker_runtime_validates_group_metadata_before_loading_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = tmp_path / "missing_repo"
+    _write_worker_plugin_dir(plugin_dir, include_repo=False)
+    metadata_path = tmp_path / "group.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "group_id": "invalid-group",
+                "plugin_entries": [
+                    {
+                        "name": "worker_manifest_plugin",
+                        "plugin_dir": str(plugin_dir),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(worker_module, "load_plugin", _fail_if_plugin_code_loads)
+
+    with pytest.raises(ValueError, match="缺少 repo"):
+        GroupWorkerRuntime(
+            transport=SimpleNamespace(),
+            group_metadata_path=metadata_path,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

Fixes #119。

#119 的问题是 direct worker 入口会绕过 discovery/supervisor 路径中的 manifest 校验：直接构造 `PluginWorkerRuntime(plugin_dir=...)` 或 `GroupWorkerRuntime(plugin_dirs=.../group_metadata_path=...)` 时，非法 `plugin.yaml` 可能进入插件代码加载阶段。

## 修复

- 在 worker 直接加载插件清单后统一调用 `validate_plugin_spec`。
- 让 `PluginWorkerRuntime`、`GroupWorkerRuntime(plugin_dirs=...)`、`GroupWorkerRuntime(group_metadata_path=...)` 复用同一个私有校验 helper。
- 保持运行时根导出和公开 API 不变。

## 测试

- 新增 `PluginWorkerRuntime(plugin_dir=...)` 缺少 `author` 时必须在 `load_plugin` 前失败。
- 新增 `GroupWorkerRuntime(plugin_dirs=...)` 缺少 `repo` 时必须在 `load_plugin` 前失败。
- 新增 group metadata 插件条目缺少 `repo` 时必须在 `load_plugin` 前失败。
- 调整 bootstrap codec 测试，让它们继续只验证 codec 选择，不被 fake spec 的完整性影响。

## 验证

- `ruff format .`
- `ruff check . --fix`
- `mypy --follow-imports=skip --ignore-missing-imports src/astrbot_sdk/runtime/worker.py`
- `python -m pytest tests/test_runtime_worker.py tests/test_runtime_bootstrap.py -q` -> `25 passed`
- `python -m pytest tests -q` -> `321 passed, 3 warnings`

## Rubric Tree

5 个独立 Tree Grading 评审全部通过且分数大于 4：

- 4.4
- 4.5
- 4.7
- 4.8
- 5.0

本 PR 仅创建，不合并。