### PR TITLE
chore :wastebasket: : 移除 Claude 本地配置并忽略 pipeline 产物

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(python -c \"import importlib.resources as r; p = r.files\\(''astrbot_sdk''\\).joinpath\\(''templates'', ''skills'', ''astrbot-plugin-dev''\\); print\\(''exists:'', p.is_dir\\(\\)\\)\")"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ plugins/.venv/
 .uv-cache/
 .astrbot/
 .codex-local/
+.claude/
+
+# Multi-agent pipeline artifacts
+.pipeline-workspace/
+.pipeline-workspace/**
+.pipeline-last-run-summary.json
 
 # IDE files
 .idea/


### PR DESCRIPTION
## 背景

仓库里误跟踪了本地 Claude 配置目录中的 `settings.local.json`，同时 multi-agent pipeline 运行产物也应保持为本地临时文件，不应进入版本库。

## 改动

- 删除已跟踪的 `.claude/settings.local.json`。
- 在 `.gitignore` 中忽略 `.claude/`。
- 在 `.gitignore` 中忽略 `.pipeline-workspace/`。
- 在 `.gitignore` 中忽略 `.pipeline-last-run-summary.json`。

## 验证

- `git diff --cached --check` 通过。
- 未运行单元测试：本 PR 只调整仓库元数据和忽略规则，不涉及运行时代码。