### PR TITLE
fix(runtime): handle HTTP API method registration

### DIFF
--- a/docs/01_context_api.md
+++ b/docs/01_context_api.md
@@ -779,6 +779,8 @@ await ctx.message_history.delete_all(session)
 `ctx.http.register_api()` 会强制要求 route 使用 `/{plugin_id}` 或 `/{plugin_id}/...`，
 并校验 `handler_capability` 必须属于当前插件。`ctx.http.unregister_api(route)` 在不传
 `methods` 时会移除当前插件在该路由下注册的全部方法。
+同一插件重复注册相同 route 和 method 时，新的 handler 会替换该 method 的旧 handler；
+未重叠的 method 会保留原有注册。
 
 如果路由和 handler 在插件定义阶段就固定了，优先考虑使用
 `@http_api(...) + @provide_capability(...)` 的声明式写法。它会在插件启动时自动注册，

--- a/docs/05_clients.md
+++ b/docs/05_clients.md
@@ -297,6 +297,8 @@ from astrbot_sdk.decorators import provide_capability
 当前实现会强制要求 route 使用 `/{plugin_id}` 或 `/{plugin_id}/...`，并校验
 `handler_capability` 必须属于当前插件。`unregister_api(route)` 在不传 `methods`
 时会移除当前插件在该 route 下注册的全部方法。
+同一插件重复注册相同 route 和 method 时，新的 handler 会替换该 method 的旧 handler；
+未重叠的 method 会保留原有注册。
 
 #### register_api()
 
@@ -510,6 +512,6 @@ async def setup_api(event: MessageEvent, ctx: Context):
 2. 远程调用可能失败，建议使用 try-except
 3. `Memory` 适合语义检索，`DB` 适合结构化 KV，`MessageHistory` 适合精确保存原始消息记录
 4. `DBClient` 的 key 对插件隔离；`list()` 返回的 key 仍是插件本地视图；`ctx.db.watch()` 在当前 Core bridge MVP 暂不支持
-5. `HTTPClient.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 归属当前插件；`unregister_api(route)` 默认移除该 route 下全部方法
+5. `HTTPClient.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 归属当前插件；重复注册相同 route/method 会替换旧 handler；`unregister_api(route)` 默认移除该 route 下全部方法
 6. 文件操作使用 file service 注册令牌
 7. 平台会话标识使用 `MessageSession` 字符串格式：`"platform_id:message_type:session_id"`，例如 `mock-platform:private:user-42` 或 `mock-platform:group:room-7`

--- a/docs/api/clients.md
+++ b/docs/api/clients.md
@@ -733,6 +733,9 @@ from astrbot_sdk.clients import HTTPClient
 - `methods` (`list[str] | None`): HTTP 方法列表
 - `description` (`str`): API 描述
 
+同一插件重复注册相同 route 和 method 时，新的 handler 会替换该 method 的旧 handler；
+未重叠的 method 会保留原有注册。
+
 **示例**:
 
 ```python
@@ -1746,7 +1749,7 @@ async def handle_message(event: MessageEvent, ctx: Context):
 2. 远程调用可能失败，建议使用 try-except 处理
 3. Memory 适合语义搜索，DB 适合结构化 KV，MessageHistory 适合精确保存原始消息记录
 4. DB key 在运行时按插件隔离；`list()` 和 `watch()` 返回插件本地 key 视图
-5. `HTTPClient.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 归属当前插件；`unregister_api(route)` 默认移除该 route 下全部方法
+5. `HTTPClient.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 归属当前插件；重复注册相同 route/method 会替换旧 handler；`unregister_api(route)` 默认移除该 route 下全部方法
 6. 文件操作使用 file service 注册令牌
 7. 平台标识使用 UMO 格式：`"platform:instance:session_id"`
 

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -819,6 +819,8 @@ await ctx.message_history.delete_all(session)
 当前实现会强制要求 route 使用 `/{plugin_id}` 或 `/{plugin_id}/...`，并校验
 `handler_capability` 必须属于当前插件。`unregister_api(route)` 在不传 `methods`
 时会移除当前插件在该 route 下注册的全部方法。
+同一插件重复注册相同 route 和 method 时，新的 handler 会替换该 method 的旧 handler；
+未重叠的 method 会保留原有注册。
 
 #### 方法
 
@@ -1604,7 +1606,7 @@ async def setup_api(event: MessageEvent, ctx: Context):
 
 6. **DB 作用域**: `ctx.db` 的 key 会自动限制在当前插件命名空间中
 
-7. **HTTP 路由**: `ctx.http.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 属于当前插件
+7. **HTTP 路由**: `ctx.http.register_api()` 会强制要求 route 使用 `/{plugin_id}` 前缀，并校验 `handler_capability` 属于当前插件；重复注册相同 route/method 会替换旧 handler
 
 8. **平台标识**: 使用 UMO（统一消息来源标识）格式：`"platform:instance:session_id"`
 

--- a/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/http.py
+++ b/src/astrbot_sdk/runtime/_capability_router_builtins/capabilities/http.py
@@ -84,7 +84,14 @@ class HttpCapabilityMixin(CapabilityRouterBridgeBase):
         plugin_name = self._require_caller_plugin_id("http.register_api")
         _validate_plugin_route_namespace(route, plugin_name)
         _validate_handler_capability_namespace(handler_capability, plugin_name)
-        methods = sorted({method.upper() for method in methods_payload if method})
+        methods = sorted(
+            {method.strip().upper() for method in methods_payload if method.strip()}
+        )
+        if not methods:
+            raise AstrBotError.invalid_input(
+                "http.register_api 的 methods 至少需要包含一个非空 HTTP method"
+            )
+        method_set = set(methods)
         entry: dict[str, Any] = {
             "route": route,
             "methods": methods,
@@ -92,15 +99,17 @@ class HttpCapabilityMixin(CapabilityRouterBridgeBase):
             "description": str(payload.get("description", "")),
             "plugin_id": plugin_name,
         }
-        self.http_api_store = [
-            item
-            for item in self.http_api_store
-            if not (
-                item.get("route") == route
-                and item.get("plugin_id") == entry["plugin_id"]
-                and item.get("methods") == methods
-            )
-        ]
+        updated: list[dict[str, Any]] = []
+        for item in self.http_api_store:
+            if item.get("route") != route or item.get("plugin_id") != plugin_name:
+                updated.append(item)
+                continue
+            remaining_methods = [
+                method for method in item.get("methods", []) if method not in method_set
+            ]
+            if remaining_methods:
+                updated.append({**item, "methods": remaining_methods})
+        self.http_api_store = updated
         self.http_api_store.append(entry)
         return {}
 

--- a/tests/test_http_runtime.py
+++ b/tests/test_http_runtime.py
@@ -29,6 +29,177 @@ async def _call(
 
 
 @pytest.mark.asyncio
+async def test_http_register_rejects_empty_method_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    router = CapabilityRouter()
+
+    with pytest.raises(AstrBotError) as exc_info:
+        await _call(
+            router,
+            "http.register_api",
+            {
+                "route": "/test-plugin/demo",
+                "methods": [],
+                "handler_capability": "test-plugin.handler",
+                "description": "demo",
+            },
+        )
+
+    assert exc_info.value.code == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_http_register_rejects_methods_empty_after_trimming(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    router = CapabilityRouter()
+
+    with pytest.raises(AstrBotError) as exc_info:
+        await _call(
+            router,
+            "http.register_api",
+            {
+                "route": "/test-plugin/demo",
+                "methods": ["", " ", "\t"],
+                "handler_capability": "test-plugin.handler",
+                "description": "demo",
+            },
+        )
+
+    assert exc_info.value.code == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_http_register_canonicalizes_methods(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    router = CapabilityRouter()
+
+    await _call(
+        router,
+        "http.register_api",
+        {
+            "route": "/test-plugin/demo",
+            "methods": ["get", " POST ", "GET"],
+            "handler_capability": "test-plugin.handler",
+            "description": "demo",
+        },
+    )
+
+    listed = await _call(router, "http.list_apis", {})
+
+    assert listed == {
+        "apis": [
+            {
+                "route": "/test-plugin/demo",
+                "methods": ["GET", "POST"],
+                "handler_capability": "test-plugin.handler",
+                "description": "demo",
+                "plugin_id": "test-plugin",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_duplicate_route_replaces_overlapping_methods_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    router = CapabilityRouter()
+
+    await _call(
+        router,
+        "http.register_api",
+        {
+            "route": "/test-plugin/demo",
+            "methods": ["GET", "POST"],
+            "handler_capability": "test-plugin.old",
+            "description": "old",
+        },
+    )
+    await _call(
+        router,
+        "http.register_api",
+        {
+            "route": "/test-plugin/other",
+            "methods": ["PATCH"],
+            "handler_capability": "test-plugin.other",
+            "description": "other route",
+        },
+    )
+    await _call(
+        router,
+        "http.register_api",
+        {
+            "route": "/other-plugin/demo",
+            "methods": ["POST"],
+            "handler_capability": "other-plugin.handler",
+            "description": "other plugin",
+        },
+        plugin_id="other-plugin",
+    )
+    await _call(
+        router,
+        "http.register_api",
+        {
+            "route": "/test-plugin/demo",
+            "methods": ["post", "DELETE"],
+            "handler_capability": "test-plugin.new",
+            "description": "new",
+        },
+    )
+
+    listed = await _call(router, "http.list_apis", {})
+    other_listed = await _call(router, "http.list_apis", {}, plugin_id="other-plugin")
+
+    assert listed == {
+        "apis": [
+            {
+                "route": "/test-plugin/demo",
+                "methods": ["GET"],
+                "handler_capability": "test-plugin.old",
+                "description": "old",
+                "plugin_id": "test-plugin",
+            },
+            {
+                "route": "/test-plugin/other",
+                "methods": ["PATCH"],
+                "handler_capability": "test-plugin.other",
+                "description": "other route",
+                "plugin_id": "test-plugin",
+            },
+            {
+                "route": "/test-plugin/demo",
+                "methods": ["DELETE", "POST"],
+                "handler_capability": "test-plugin.new",
+                "description": "new",
+                "plugin_id": "test-plugin",
+            },
+        ]
+    }
+    assert other_listed == {
+        "apis": [
+            {
+                "route": "/other-plugin/demo",
+                "methods": ["POST"],
+                "handler_capability": "other-plugin.handler",
+                "description": "other plugin",
+                "plugin_id": "other-plugin",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
 async def test_http_unregister_empty_methods_removes_all_for_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 背景

Closes #120 

当前 `http.register_api` 对空 methods 和同 route 重叠 methods 的处理不明确：

- `methods=[]` 或归一化后为空的 methods 会被接受
- 同一插件同一路由重复注册部分重叠 method 时，只按完整 methods 列表去重，导致旧 handler 和新 handler 可能同时持有同一个 method

这会让 HTTP route registry 出现重复、陈旧或歧义映射。

## 改动

- `http.register_api` 注册阶段统一对 methods 做：
  - `strip`
  - `upper`
  - 去空
  - 去重
  - 排序
- 拒绝归一化后为空的 method 列表，抛出 `invalid_input`
- 同一插件同一路由重复注册时，按 method 粒度替换：
  - 重叠 method 使用新 handler
  - 非重叠旧 method 保留
  - 其他 route / 其他 plugin 的注册不受影响
- 保持 `http.unregister_api(methods=[])` 语义不变：删除当前插件当前 route 下全部 methods
- 补充 HTTP API 注册覆盖语义文档
- 新增回归测试覆盖空 methods、method 归一化、重叠 method 替换和隔离行为

## 验证

- `ruff format .`
- `ruff check . --fix`
- `.venv/bin/python -m pytest tests/test_http_runtime.py -q`
  - `9 passed`
- `.venv/bin/python -m pytest tests -q`
  - `324 passed`